### PR TITLE
Add manual Astro build workflow

### DIFF
--- a/.github/workflows/manual-astro-build.yml
+++ b/.github/workflows/manual-astro-build.yml
@@ -1,0 +1,23 @@
+name: Manual Astro Build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Astro site
+        run: npm run build


### PR DESCRIPTION
## Summary
- add a workflow_dispatch GitHub Actions workflow to build the Astro site with npm

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0e5541cf88320b0e06e7f98d68281